### PR TITLE
Make app's pkg sources CRAN-focused (temporarily)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: riskassessment
 Title: A web app designed to interface with the `riskmetric` package
-Version: 0.0.1.9032
+Version: 0.0.1.9033
 Authors@R: c( 
     person("Aaron", "Clark", role = c("aut", "cre"), email = "aaron.clark@biogen.com"),
     person("Robert", "Krajcik", role = "aut", email = "robert.krajcik@biogen.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 * Fixed bug where the logging file was not being set
 * Source riskmetric from GitHub
 * Added decision automation capabilities where the user can set decision rules for uploaded packages to be auto-assigned
+* Adopt (temporary) CRAN-first data collection method for pkg info via `riskmetric::pkg_ref()`
 
 # riskassessment 0.0.1
 * Initiated simple `app.R` for easier deployment using `runURL("https://github.com/pharmaR/riskassessment/archive/master.zip")` and `shiny::runGitHub('riskassessment', 'pharmaR')`

--- a/R/mod_uploadPackage.R
+++ b/R/mod_uploadPackage.R
@@ -251,7 +251,7 @@ uploadPackageServer <- function(id, user) {
             
             if (grepl("^[[:alpha:]][[:alnum:].]*[[:alnum:]]$", uploaded_packages$package[i])) {
               # run pkg_ref() to get pkg version and source info
-              ref <- riskmetric::pkg_ref(uploaded_packages$package[i])
+              ref <- riskmetric::pkg_ref(uploaded_packages$package[i], repos = c("https://cran.rstudio.com"))
             } else {
               ref <- list(name = uploaded_packages$package[i],
                           source = "name_bad")

--- a/R/utils_insert_db.R
+++ b/R/utils_insert_db.R
@@ -144,7 +144,7 @@ insert_riskmetric_to_db <- function(pkg_name,
     db_name = golem::get_golem_options('assessment_db_name')){
 
   riskmetric_assess <-
-    riskmetric::pkg_ref(pkg_name) %>%
+    riskmetric::pkg_ref(pkg_name, repos = c("https://cran.rstudio.com")) %>%
     dplyr::as_tibble() %>%
     riskmetric::pkg_assess()
   


### PR DESCRIPTION
Why? Well, to gain unity on  version discrepancies, fixing:
* #412
* #385

And also, to fix part of #410, since any pkg that has a newer release than what's in our `renv.lock` file get's borked metrics on upload. More discussion is yet to be had on how to fix #410 for the future.
