### PR TITLE
fix warning message generated from get_latest_pkg_info()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -64,8 +64,8 @@ get_latest_pkg_info <- function(pkg_name) {
     dplyr::filter(X1 %in% c("Version", "Maintainer", "Author", "License", "Published"))
   
   table_infy <- t(table_infx$X2) %>% dplyr::as_tibble(.name_repair = "minimal")
-  colnames(table_infy) <- t(table_infx$X1) %>% dplyr::as_tibble(.name_repair = "minimal") 
-  
+  colnames(table_infy) <- t(table_infx$X1) %>% as.vector()
+
   table_info <- table_infy %>% 
     dplyr::select(Version, Maintainer, Author, License, Published) %>%
     dplyr::mutate(Title = title, Description = description)


### PR DESCRIPTION
This is just a one-line fix to remove a warning message coming from two tests.
The fix was to replace a line in function `get_latest_pkg_info()`
from
`colnames(table_infy) <- t(table_infx$X1) %>% dplyr::as_tibble(.name_repair = "minimal") `
to
`colnames(table_infy) <- t(table_infx$X1) %>% as.vector() `

Verification:  run individual tests for `test-dbUpdate` and `test-utils_get_db`