### PR TITLE
Database Overview: Initial export

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: riskassessment
 Title: A web app designed to interface with the `riskmetric` package
-Version: 0.1.0.9010
+Version: 0.1.0.9011
 Authors@R: c( 
     person("Aaron", "Clark", role = c("aut", "cre"), email = "aaron.clark@biogen.com"),
     person("Robert", "Krajcik", role = "aut", email = "robert.krajcik@biogen.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: riskassessment
 Title: A web app designed to interface with the `riskmetric` package
-Version: 0.1.0.9009
+Version: 0.1.0.9010
 Authors@R: c( 
     person("Aaron", "Clark", role = c("aut", "cre"), email = "aaron.clark@biogen.com"),
     person("Robert", "Krajcik", role = "aut", email = "robert.krajcik@biogen.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,9 @@
 * Added check that URLs needed to upload packages are reachable
 * Added Riskassessment logo for docx and pdf reports
 * Add button that redirects to pkg metrics
-
+* Added Excel & CSV export options on Database View tab
+* Added 'search' capability to database view tab
+* Some general aesthetic improvements, for example: made sure tab headers were a consistent size
 
 # riskassessment 0.1.0
 

--- a/R/mod_assessmentInfo.R
+++ b/R/mod_assessmentInfo.R
@@ -11,8 +11,7 @@ assessmentInfoUI <- function(id) {
     fluidRow(
       column(
         width = 8, offset = 2,
-        br(),
-        h4("Assessment Criteria Overview"),
+        h2("Assessment Criteria Overview", align = "center", `padding-bottom`="20px"),
         br(),
         tabsetPanel(
           tabPanel(

--- a/R/mod_databaseView.R
+++ b/R/mod_databaseView.R
@@ -23,13 +23,11 @@ databaseViewUI <- function(id) {
     fluidRow(
       column(
         width = 8, offset = 2, align = "center",
-        br(),
-        h4("Database Overview"),
-        hr(),
+        h2("Database Overview", align = "center", `padding-bottom`="20px"),
         tags$section(
           br(), br(),
           shinydashboard::box(width = 12,
-              title = h5("Uploaded Packages", style = "margin-top: 5px"),
+              title = h3("Uploaded Packages", style = "margin-top: 5px"),
               DT::dataTableOutput(NS(id, "packages_table")),
               br(),
               fluidRow(
@@ -110,13 +108,15 @@ databaseViewServer <- function(id, user, uploaded_pkgs, metric_weights, changes,
     )
     
     # Create table for the db dashboard.
-    output$packages_table <- DT::renderDataTable({
+    output$packages_table <- DT::renderDataTable(server = FALSE, {  # This allows for downloading entire data set
       
       my_data_table <- reactive({
         cbind(table_data(), 
         data.frame(
           Actions = shinyInput(actionButton, nrow(table_data()),
                                'button_',
+                               size = "xs",
+                               style='height:24px; padding-top:1px;',
                                label = icon("arrow-right", class="fa-regular", lib = "font-awesome"),
                                onclick = paste0('Shiny.onInputChange(\"' , ns("select_button"), '\", this.id)')
           )
@@ -156,14 +156,23 @@ databaseViewServer <- function(id, user, uploaded_pkgs, metric_weights, changes,
         selection = list(mode = 'multiple'),
         colnames = c("Package", "Version", "Score", "Decision Made?", "Decision", "Last Comment", "Explore Metrics"),
         rownames = FALSE,
+        extensions = "Buttons",
         options = list(
-          searching = FALSE,
+          searching = TRUE,
           lengthChange = FALSE,
-          #dom = 'Blftpr',
+          dom = 'Blftpr',
           pageLength = 15,
           lengthMenu = list(c(15, 60, 120, -1), c('15', '60', '120', "All")),
-          columnDefs = list(list(className = 'dt-center', targets = "_all"))
+          columnDefs = list(list(className = 'dt-center', targets = "_all")),
+          buttons = list(
+            list(extend = "excel", text = shiny::HTML('<i class="fas fa-download"></i> Excel'),
+                 exportOptions = list(columns = c(0:5)), # which columns to download
+                 filename = paste("{riskassessment} pkgs " ,stringr::str_replace_all(paste(Sys.time()),":", "."))),
+            list(extend = "csv", text = shiny::HTML('<i class="fas fa-download"></i> CSV'),
+                 exportOptions = list(columns = c(0:5)), # which columns to download
+                 filename = paste("{riskassessment} pkgs " ,stringr::str_replace_all(paste(Sys.time()),":", "."))))
         )
+        , style="default"
       ) %>%
         DT::formatStyle(names(table_data()), textAlign = 'center')
     })


### PR DESCRIPTION
Partially closes #383 by including:
* really low hanging fruit of adding an excel/csv download
* cleans up some header inconsistencies from tab to tab
* made 'Explore Metrics' button more compact so that more pkgs can fit on one page, reducing user scroll
* adds search capability so that users can find a package faster