### PR TITLE
Update `README` with pharmaverse badge

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -16,10 +16,11 @@ knitr::opts_chunk$set(
 # The `{riskassessment}` application <a href='https://bit.ly/raa_docs'><img src="man/figures/hex-riskassessment-aspconfig.png" align="right" height="172" style="float:right; height:172px;"/></a>
 
 <!-- badges: start -->
+[![pharmaverse](http://pharmaverse.org/shields/riskassessment.svg)](https://pharmaverse.org/e2eclinical/validation/)
 [<img src="https://img.shields.io/badge/Slack-RValidationHub-blue?style=flat&logo=slack">](https://RValidationHub.slack.com)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![R-CMD-check](https://github.com/pharmaR/riskassessment/actions/workflows/R-CMD-check-master.yaml/badge.svg)](https://github.com/pharmaR/riskassessment/actions/workflows/R-CMD-check.yaml)
 [![Coverage status](https://codecov.io/gh/pharmaR/riskassessment/branch/master/graph/badge.svg)](https://app.codecov.io/github/pharmaR/riskassessment)
-[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
 `riskassessment` is an R package containing a shiny front-end to augment the utility of the [`riskmetric`](https://github.com/pharmaR/riskmetric) package within an organizational context. Recently awarded the title for "Best App" at [Shiny Conf 2023](https://bit.ly/raa_shinyconf23) (see [Recognition](#recognition) section below).

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@
 
 <!-- badges: start -->
 
+[![pharmaverse](http://pharmaverse.org/shields/riskassessment.svg)](https://pharmaverse.org/e2eclinical/validation/)
 [<img src="https://img.shields.io/badge/Slack-RValidationHub-blue?style=flat&logo=slack">](https://RValidationHub.slack.com)
+[![Lifecycle:
+experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![R-CMD-check](https://github.com/pharmaR/riskassessment/actions/workflows/R-CMD-check-master.yaml/badge.svg)](https://github.com/pharmaR/riskassessment/actions/workflows/R-CMD-check.yaml)
 [![Coverage
 status](https://codecov.io/gh/pharmaR/riskassessment/branch/master/graph/badge.svg)](https://app.codecov.io/github/pharmaR/riskassessment)
-[![Lifecycle:
-experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
 `riskassessment` is an R package containing a shiny front-end to augment
@@ -53,8 +54,8 @@ reviewer to:
 
 Validation can serve as an umbrella for various terms, and admittedly,
 companies will diverge on what may be the “correct approach”. The
-`riskassessment` app is built on a `riskmetric`-foundation, whose
-developers follow the validation philosophy proposed in [this white
+`riskassessment` app is built on a `rismetric`-foundation, whose
+deverlopers follow the validation philosophy proposed in [this white
 paper](https://www.pharmar.org/white-paper/) published by the R
 Validation Hub. As such, the scope of `riskassessment` and `riskmetric`
 are only designed to support decision making from that view point. The


### PR DESCRIPTION
As of today, `riskassesment` is officially featured on https://pharmaverse.org/e2eclinical/validation/ and our badge is being hosted there as well. This PR just adds the badge to the `README` file.

![image](https://user-images.githubusercontent.com/17878953/233139112-76a629da-7835-4a48-b709-af25ed1e9ba2.png)

Note: GHAs were failing before this PR and will likely fail again. Let me know when you think it looks kosher, and I can bypass the "branch protections" and merge. Thanks!