### PR TITLE
Fix the confusing message on pkg upload progress bar (issue #515).

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: riskassessment
 Title: A web app designed to interface with the `riskmetric` package
-Version: 0.1.1.9015
+Version: 0.1.1.9016
 Authors@R: c( 
     person("Aaron", "Clark", role = c("aut", "cre"), email = "aaron.clark@biogen.com"),
     person("Robert", "Krajcik", role = "aut", email = "robert.krajcik@biogen.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Utilized `glue::glue_sql()` inside of update and select functions (#520)
 * Enhanced the "Database View" tab to include the decision category table
 * Allowed the user to set a custom color for decision categories (#465)
+* Add a check to give message about different versions only when package name is given from CSV file (#515)
 
 # riskassessment 0.1.1
 

--- a/R/mod_uploadPackage.R
+++ b/R/mod_uploadPackage.R
@@ -352,8 +352,14 @@ uploadPackageServer <- function(id, user, auto_list) {
             
             ref_ver <- as.character(ref$version)
             
-            if(user_ver == ref_ver) ver_msg <- ref_ver
-            else ver_msg <- glue::glue("{ref_ver}, not '{user_ver}'")
+            # The message about different versions is only given if the package 
+            # name is uploaded from CSV file and not if it is selected from drop-down.
+            if(isTruthy(input$load_cran)) {
+              ver_msg <- ref_ver
+            } else {
+              if(user_ver == ref_ver) ver_msg <- ref_ver
+              else ver_msg <- glue::glue("{ref_ver}, not '{user_ver}'")
+            }
             
             as.character(ref$version)
             deets <- glue::glue("{uploaded_packages$package[i]} {ver_msg}")


### PR DESCRIPTION
Added a check for packages being uploaded from the drop-down or read from CSV file.

The message about different versions is given only if the package is read from the CSV file and the version on CRAN is different from the version specified in the CSV file.