### PR TITLE
Attempted fix for known `riskmetric` weighting bug #293

### DIFF
--- a/R/mod_assessmentInfo.R
+++ b/R/mod_assessmentInfo.R
@@ -65,7 +65,7 @@ assessmentInfoServer <- function(id, metric_weights) {
     # Render table for Maintenance Metrics.
     output$riskcalc_weights_table <- DT::renderDataTable({
       d <- metric_weights() %>%
-        dplyr::mutate(weight = ifelse(name == "covr_coverage", 0, weight)) %>%
+        # dplyr::mutate(weight = ifelse(name == "covr_coverage", 0, weight)) %>%
         formattable::formattable() %>%
         dplyr::mutate(standardized_weight = round(weight / sum(weight, na.rm = TRUE), 4))
       

--- a/R/utils_insert_db.R
+++ b/R/utils_insert_db.R
@@ -163,8 +163,6 @@ insert_riskmetric_to_db <- function(pkg_name,
   
   # Get the metrics weights to be used during pkg_score.
   metric_weights_df <- dbSelect("SELECT id, name, weight FROM metric", db_name)
-  print("metric_weights_df\n")
-  print(metric_weights_df)
   
   # TODO: due to riskmetric bug (#293), need to block NA assessments from being used in score calc
   block_na_assess <- riskmetric_assess %>%
@@ -175,8 +173,6 @@ insert_riskmetric_to_db <- function(pkg_name,
     right_join(metric_weights_df, by = "name") %>%
     mutate(weight = ifelse(V1 == 0, 0, weight))
   
-  print("\nblock_na_assess\n")
-  print(block_na_assess)
   
   metric_weights <- block_na_assess$weight
   names(metric_weights) <- block_na_assess$name

--- a/inst/db-config.yml
+++ b/inst/db-config.yml
@@ -20,8 +20,6 @@ default:
       High Risk:
         - .666
         - 1
-  metric_weights:
-    covr_coverage: 0
 example:
   assessment_db: database_ex.sqlite
   credential_db: credentials_ex.sqlite

--- a/inst/sql_queries/initialize_metric_table.sql
+++ b/inst/sql_queries/initialize_metric_table.sql
@@ -11,5 +11,5 @@ VALUES
 ('export_help',         'Documentation',     '% of documented objects',          1, 0, 'maintenance', 1),
 ('bugs_status',         'Bugs Closure Rate', '% of the last 30 bugs closed',     1, 0, 'maintenance', 1),
 ('license',             'License',           "Package's license",                0, 0, 'maintenance', 1),
-('covr_coverage',       'Test Coverage',     '% of objects tested',     1, 1, 'maintenance', 0),
+('covr_coverage',       'Test Coverage',     '% of objects tested',     1, 1, 'maintenance', 1),
 ('downloads_1yr',       'Downloads',         'Number of package downloads in the last year', 0, 0, 'community', 1);


### PR DESCRIPTION
@Jeff-Thompson12, hey I was thinking about adding the top 500 pkgs to the demo version of the app, and thought it'd be a good idea to put in a little workaround to fix for https://github.com/pharmaR/riskmetric/issues/293. What are your thoughts on these changes? Should I clean them up and push them to the `dev` branch as well? The alternative is that we could wait for `{riskmetric}` to solve the bug.

Also, you'll notice I allow tracking of the `database.sql` file on this branch.