### PR TITLE
Set CRAN repo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: riskassessment
 Title: A web app designed to interface with the `riskmetric` package
-Version: 1.0.0.9010
+Version: 1.0.0.9011
 Authors@R: c( 
     person("Aaron", "Clark", role = c("aut", "cre"), email = "aaron.clark@biogen.com"),
     person("Robert", "Krajcik", role = "aut", email = "robert.krajcik@biogen.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Fixed busted button introduced with #547 (#592)
 * Allow `admin` users to edit roles and privileges (#541)
 * Prominently display the date a package was added (#486)
+* Fix issue where the repository being used to gather information was inconsistent
 
 
 # riskassessment 1.0.0

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -9,9 +9,12 @@
 #' @noRd
 app_server <- function(input, output, session) {
   
+  old <- options()
   onStop(function() {
     unlink("source/*", recursive = TRUE)
+    options(old)
     })
+  options(repos = c(CRAN = "https://cran.rstudio.com"))
   
   # Collect user info.
   user <- reactiveValues()

--- a/R/mod_uploadPackage.R
+++ b/R/mod_uploadPackage.R
@@ -358,8 +358,7 @@ uploadPackageServer <- function(id, user, auto_list, credentials, trigger_events
               ref <- list(name = uploaded_packages$package[i],
                           source = "name_bad")
             }
-            browser()
-            
+
             if (ref$source %in% c("pkg_missing", "name_bad")) {
               incProgress(1, detail = 'Package {uploaded_packages$package[i]} not found')
               

--- a/R/mod_uploadPackage.R
+++ b/R/mod_uploadPackage.R
@@ -351,14 +351,14 @@ uploadPackageServer <- function(id, user, auto_list, credentials, trigger_events
               # run pkg_ref() to get pkg version and source info
               if (!isTRUE(getOption("shiny.testmode")))
                 ref <- riskmetric::pkg_ref(uploaded_packages$package[i],
-                                           source = "pkg_cran_remote",
-                                           repos = c("https://cran.rstudio.com"))
+                                           source = "pkg_cran_remote")
               else
                 ref <- test_pkg_refs[[uploaded_packages$package[i]]]
             } else {
               ref <- list(name = uploaded_packages$package[i],
                           source = "name_bad")
             }
+            browser()
             
             if (ref$source %in% c("pkg_missing", "name_bad")) {
               incProgress(1, detail = 'Package {uploaded_packages$package[i]} not found')

--- a/R/utils_insert_db.R
+++ b/R/utils_insert_db.R
@@ -155,8 +155,7 @@ insert_riskmetric_to_db <- function(pkg_name,
   if (!isTRUE(getOption("shiny.testmode")))
     riskmetric_assess <-
       riskmetric::pkg_ref(pkg_name,
-                          source = "pkg_cran_remote",
-                          repos = c("https://cran.rstudio.com")) %>%
+                          source = "pkg_cran_remote") %>%
       dplyr::as_tibble() %>%
       riskmetric::pkg_assess()
   else


### PR DESCRIPTION
A number of functions in `{riskmetric}` run `getOption("repos")`, so to ensure that the correct repo is being used, it needs to be set in the application itself.