### PR TITLE
Dependency "Upload All" follow up#626

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: riskassessment
 Title: A web app designed to interface with the `riskmetric` package
-Version: 2.0.0.9001
+Version: 2.0.0.9002
 Authors@R: c( 
     person("Aaron", "Clark", role = c("aut", "cre"), email = "aaron.clark@biogen.com"),
     person("Robert", "Krajcik", role = "aut", email = "robert.krajcik@biogen.com"),

--- a/R/mod_packageDependencies.R
+++ b/R/mod_packageDependencies.R
@@ -153,13 +153,15 @@ packageDependenciesServer <- function(id, selected_pkg, user, changes, parent) {
                  )
                 ),
                 column(3,
-                 actionButton(
-                   inputId =  ns("update_all_packages"),
-                   label = "Upload all",
-                   icon = icon("fas fa-upload", class = "fa-regular", lib = "font-awesome"),
-                   size = "xs",
-                   style = "height:30px; padding-top:1px;"
-                 )
+                 if (nrow(depends()) > 0) {
+                   actionButton(
+                     inputId =  ns("update_all_packages"),
+                     label = "Upload all",
+                     icon = icon("fas fa-upload", class = "fa-regular", lib = "font-awesome"),
+                     size = "xs",
+                     style = "height:30px; padding-top:1px;"
+                   )
+                 } 
                 )
               ),
               br(),

--- a/R/mod_packageDependencies.R
+++ b/R/mod_packageDependencies.R
@@ -356,7 +356,7 @@ packageDependenciesServer <- function(id, selected_pkg, user, changes, parent) {
           size = "l",
           easyClose = TRUE,
           title = "Upload all packages?",
-          p(glue::glue("Do you want to upload {pkg_updates$n_packages} package(s)?")),
+          p(glue::glue("Do you want to upload {nrow(pkg_updates$pkgs_update)} package(s)?")),
            footer = tagList(
              actionButton(NS(id, "confirm"), "Load Package(s)"),
              actionButton(NS(id, "cancel"), "Cancel")


### PR DESCRIPTION
# Task

Feature task on the option to hide upload all packages when there is no package to be shown in table #626 

# This PR adds

1. Checks if there are packages to be rendered on the table and only shows upload all option when it does

![image](https://github.com/pharmaR/riskassessment/assets/8216229/1080bb32-e0ca-438d-8d27-61b6ab5d06b7)
