### PR TITLE
Improve uploading packages from dependency tab

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -238,7 +238,6 @@ app_server <- function(input, output, session) {
   dependencies_data <- packageDependenciesServer('packageDependencies',
                                                selected_pkg,
                                                user,
-                                               changes,
                                                parent = session,
                                                trigger_events)
   

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -27,7 +27,8 @@ app_server <- function(input, output, session) {
     bindEvent(credential_config$roles, credential_config$privileges)
   trigger_events <- reactiveValues(
     reset_pkg_upload = 0,
-    reset_sidebar = 0
+    reset_sidebar = 0,
+    upload_pkgs = NULL,
   )
   
   
@@ -238,7 +239,8 @@ app_server <- function(input, output, session) {
                                                selected_pkg,
                                                user,
                                                changes,
-                                               parent = session)
+                                               parent = session,
+                                               trigger_events)
   
   output$auth_output <- renderPrint({
     reactiveValuesToList(res_auth)

--- a/R/mod_packageDependencies.R
+++ b/R/mod_packageDependencies.R
@@ -28,7 +28,7 @@ packageDependenciesUI <- function(id) {
 #'
 #' @keywords internal
 #'
-packageDependenciesServer <- function(id, selected_pkg, user, changes, parent) {
+packageDependenciesServer <- function(id, selected_pkg, user, changes, parent, trigger_events) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     cran_pkgs <- as.data.frame(available.packages("https://cran.rstudio.com/src/contrib")[, 1:2])
@@ -322,14 +322,9 @@ packageDependenciesServer <- function(id, selected_pkg, user, changes, parent) {
     observeEvent(input$confirm, {
       shiny::removeModal()
       
-      updateSelectizeInput(
-        session = parent, "upload_package-pkg_lst",
-        choices = c(pkgname()), selected = pkgname()
-      )
+      trigger_events$upload_pkgs <- pkgname()
       
       session$onFlushed(function() {
-        shinyjs::click(id = "upload_package-add_pkgs", asis = TRUE)
-        
         rev_pkg(1L)
       })
     })

--- a/R/mod_packageDependencies.R
+++ b/R/mod_packageDependencies.R
@@ -12,8 +12,8 @@ packageDependenciesUI <- function(id) {
 #' @param id a module id name
 #' @param selected_pkg placeholder
 #' @param user placeholder
-#' @param changes a reactive value integer count
 #' @param parent the parent (calling module) session information
+#' @param trigger_events a reactive values object to trigger actions here or elsewhere
 #'
 #' @import dplyr
 #' @importFrom DT formatStyle renderDataTable
@@ -28,12 +28,12 @@ packageDependenciesUI <- function(id) {
 #'
 #' @keywords internal
 #'
-packageDependenciesServer <- function(id, selected_pkg, user, changes, parent, trigger_events) {
+packageDependenciesServer <- function(id, selected_pkg, user, parent, trigger_events) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     cran_pkgs <- as.data.frame(available.packages("https://cran.rstudio.com/src/contrib")[, 1:2])
     
-    loaded2_db <- eventReactive(list(selected_pkg$name(), changes()), {
+    loaded2_db <- eventReactive(selected_pkg$name(), {
       dbSelect("SELECT name, version, score FROM package")
     })
     
@@ -55,7 +55,7 @@ packageDependenciesServer <- function(id, selected_pkg, user, changes, parent, t
     depends  <- reactiveVal(value = NULL)
     suggests <- reactiveVal(value = NULL)
     revdeps  <- reactiveVal(value = NULL)
-    rev_pkg  <- reactiveVal(value = NULL)
+    rev_pkg  <- reactiveVal(value = 0L)
     toggled  <- reactiveVal(value = 0L)
     pkg_updates <- reactiveValues()
 
@@ -71,7 +71,7 @@ packageDependenciesServer <- function(id, selected_pkg, user, changes, parent, t
      
     })
     
-    pkgref <- eventReactive(list(selected_pkg$name(), changes(), tabready()), {
+    pkgref <- eventReactive(list(selected_pkg$name(), tabready()), {
       req(selected_pkg$name())
       req(selected_pkg$name() != "-")
       req(tabready() == 1L)
@@ -334,25 +334,22 @@ packageDependenciesServer <- function(id, selected_pkg, user, changes, parent, t
       shiny::removeModal()
     })
     
-    names_vect <- eventReactive(list(rev_pkg(), changes()), {
+    names_vect <- eventReactive(rev_pkg(), {
       req(rev_pkg() == 1L)
       dbSelect("SELECT name FROM package")$name
     })
     
-    observeEvent(names_vect(),
-     {
-       pkg_name <- names_vect()[length(names_vect())]
-       
-       updateSelectizeInput(
-         session = parent,
-         inputId = "sidebar-select_pkg",
-         choices = c("-", loaded2_db()$name),
-         selected = pkg_name
-       )
-     },
-     ignoreInit = TRUE
-    )
-
+    observeEvent(names_vect(), {
+      req(names_vect())
+      pkg_name <- names_vect()[length(names_vect())]
+      updateSelectizeInput(
+        session = parent,
+        inputId = "sidebar-select_pkg",
+        choices = c("-", names_vect()),
+        selected = pkg_name
+      )
+    })
+    
     observe({
       if (nrow(pkg_df()) > 0) {
         pkg_updates$pkgs_update <- pkg_df() %>%
@@ -367,6 +364,7 @@ packageDependenciesServer <- function(id, selected_pkg, user, changes, parent, t
     
     observeEvent(input$update_all_packages, {
       req(pkg_df(), loaded2_db(), pkg_updates)
+      rev_pkg(0L)
 
       pkgname(pkg_updates$pkgs_update$name)
       shiny::showModal(

--- a/R/mod_uploadPackage.R
+++ b/R/mod_uploadPackage.R
@@ -225,6 +225,20 @@ uploadPackageServer <- function(id, user, auto_list, credentials, trigger_events
       uploaded_pkgs00(uploaded_packages)
     })
     
+    observeEvent(trigger_events$upload_pkgs, {
+      req(trigger_events$upload_pkgs)
+      
+      np <- length(trigger_events$upload_pkgs)
+      uploaded_packages <-
+        dplyr::tibble(
+          package = trigger_events$upload_pkgs,
+          version = rep('0.0.0', np),
+          status = rep('', np)
+        )
+      
+      uploaded_pkgs00(uploaded_packages)
+    })
+    
     observeEvent(input$rem_pkg_btn, {
       req("delete_package" %in% credentials$privileges[[user$role]]) 
       

--- a/man/packageDependenciesServer.Rd
+++ b/man/packageDependenciesServer.Rd
@@ -4,7 +4,7 @@
 \alias{packageDependenciesServer}
 \title{Package Dependencies module's server logic}
 \usage{
-packageDependenciesServer(id, selected_pkg, user, changes, parent)
+packageDependenciesServer(id, selected_pkg, user, parent, trigger_events)
 }
 \arguments{
 \item{id}{a module id name}
@@ -13,9 +13,9 @@ packageDependenciesServer(id, selected_pkg, user, changes, parent)
 
 \item{user}{placeholder}
 
-\item{changes}{a reactive value integer count}
-
 \item{parent}{the parent (calling module) session information}
+
+\item{trigger_events}{a reactive values object to trigger actions here or elsewhere}
 }
 \description{
 Package Dependencies module's server logic


### PR DESCRIPTION
This PR seeks to improve on the current process in two main ways:

1. Utilizing the `trigger_events` reactive values list
The current process overwrites the list of options for adding a package. It also relies on interactions with the UI when a more direct interaction is possible and probably preferrable.

2. Remove the dependence on the reactive `changes()`
While using `changes()` works, it also causes events to trigger multiple times and other times when unneeded. Also, `changes()` is set to update whenever a decision of overall comment is added to a package. This unnecessarily complicates the reactive graph because neither of those two events are the events desired to being tracked. The reactive is merely changing as a byproduct of the package selection changing. This PR makes the reactive graph more readable in that regard. 