### PR TITLE
Force new lines in card paragraphs

### DIFF
--- a/R/mod_metricBox.R
+++ b/R/mod_metricBox.R
@@ -74,7 +74,7 @@ metricBoxServer <- function(id, title, desc, value, score = "NULL",
         size_min = .85, size_max = 1.5
       ) # , num_bins = 3
       
-      body_p_style <- glue::glue("font-size: {auto_font_out}vw")
+      body_p_style <- glue::glue("font-size: {auto_font_out}vw;")
       
       # build the html card
       if(score == "NULL" | # usually for non-riskmetric cards (like on comm or database tab)
@@ -118,7 +118,7 @@ metricBoxServer <- function(id, title, desc, value, score = "NULL",
             ),
             div(
               class = "card-body text-info",
-              p(class = "card-title", style = body_p_style, value)
+              p(class = "card-title", style = c(body_p_style, if (!is_url) "white-space: pre-wrap;"), value)
             )
           ),
           div(class = "card-footer bg-transparent", desc)

--- a/inst/report_downloads/reportHtml.Rmd
+++ b/inst/report_downloads/reportHtml.Rmd
@@ -98,7 +98,7 @@ createCard <- function(title, desc, value, score = "NULL",
   card_style <- "max-width: 400px; max-height: 250px; padding-left: 5%; padding-right: 5%;" 
   auto_font_out <- auto_font(value, txt_max = val_max_nchar,
                              size_min = .85, size_max = 1.5)
-  body_p_style = glue::glue('font-size: {auto_font_out}vw')
+  body_p_style = glue::glue('font-size: {auto_font_out}vw;')
       
   
   # build the html card
@@ -138,7 +138,7 @@ createCard <- function(title, desc, value, score = "NULL",
               h5(class="card-header bg-transparent", style="font-size: 1vw",
                  title),
               div(class="card-body text-info",
-                  p(class="card-title", style=body_p_style, value))),
+                  p(class="card-title", style=c(body_p_style, if (!is_url) "white-space: pre-wrap;"), value))),
           div(class="card-footer bg-transparent", desc)
       )
   )


### PR DESCRIPTION
Forces the new lines to be recognized in the cards. Or makes this:
![image](https://github.com/pharmaR/riskassessment/assets/85879620/4c19427e-5f3d-459a-aae2-ea38d6dc42fd)
into this:
![image](https://github.com/pharmaR/riskassessment/assets/85879620/0f49563d-4469-47d3-8f92-f0217e3c2460)
