### PR TITLE
Specify `keep_source = TRUE` argument in `parse()`

### DIFF
--- a/R/mod_code_explorer_utils.R
+++ b/R/mod_code_explorer_utils.R
@@ -40,7 +40,7 @@ get_parse_data <- function(type = c("test", "source"), pkgdir, funcnames = NULL)
   )
   filenames <- list.files(dirpath, ".+\\.[R|r]$")
   dplyr::bind_rows(lapply(filenames, function(filename) {
-    d <- parse(file.path(dirpath, filename)) %>% 
+    d <- parse(file.path(dirpath, filename), keep.source = TRUE) %>% 
       utils::getParseData() %>% 
       dplyr::filter(token %in% c("SYMBOL_FUNCTION_CALL", "SYMBOL", "SPECIAL"))
     d <- d %>% 


### PR DESCRIPTION
The `keep_source` argument in the `parse()` function in base R defaults to `getOption("keep.source")`. This is typically `TRUE` when ran locally but `FALSE` when deployed. The source code is necessary for `utils::getParseData()` to work correctly, so it should be set to `TRUE` in all cases.