### PR TITLE
Fix `selectizeInput()` on `Upload Pkgs` tab

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * Fixed bug with the logo's hyperlink not functioning in the expected zone (#633)
 * Removed suggests from riskcalc weights table (#646)
 * Forced new lines in card paragraphs (#671)
+* Ensured users couldn't create & select packages from CRAN that don't exist on Upload Packages Tab
 
 ### For Devs
 * Migrated from `{jsTreeR}` to `{shinyTree}` (#585)

--- a/R/mod_uploadPackage.R
+++ b/R/mod_uploadPackage.R
@@ -23,7 +23,7 @@ uploadPackageUI <- function(id) {
           style = "display: flex;",
           shinyjs::disabled(
             selectizeInput(NS(id, "pkg_lst"), "Type Package Name(s)", choices = NULL, multiple = TRUE, 
-                           options = list(create = FALSE, showAddOptionOnCreate = FALSE, 
+                           options = list(selectOnTab = TRUE, showAddOptionOnCreate = FALSE, 
                                           onFocus = I(paste0('function() {Shiny.setInputValue("', NS(id, "load_cran"), '", "load", {priority: "event"})}')))),
             actionButton(NS(id, "add_pkgs"), shiny::icon("angle-right"),
                          style = 'height: calc(1.5em + 1.5rem + 2px)')),
@@ -179,7 +179,7 @@ uploadPackageServer <- function(id, user, auto_list, credentials, parent) {
         id = "rem-package-group",
         style = "display: flex;",
         selectizeInput(NS(id, "rem_pkg_lst"), "Remove Package(s)", choices = NULL, multiple = TRUE,
-                       options = list(create = FALSE, showAddOptionOnCreate = FALSE, 
+                       options = list(selectOnTab = TRUE, showAddOptionOnCreate = FALSE, 
                                       onFocus = I(paste0('function() {Shiny.setInputValue("', NS(id, "curr_pkgs"), '", "load", {priority: "event"})}')))),
         # note the action button moved out of alignment with 'selectizeInput' under 'renderUI'
         actionButton(NS(id, "rem_pkg_btn"), shiny::icon("trash-can")),

--- a/R/mod_uploadPackage.R
+++ b/R/mod_uploadPackage.R
@@ -23,7 +23,7 @@ uploadPackageUI <- function(id) {
           style = "display: flex;",
           shinyjs::disabled(
             selectizeInput(NS(id, "pkg_lst"), "Type Package Name(s)", choices = NULL, multiple = TRUE, 
-                           options = list(create = TRUE, showAddOptionOnCreate = FALSE, 
+                           options = list(create = FALSE, showAddOptionOnCreate = FALSE, 
                                           onFocus = I(paste0('function() {Shiny.setInputValue("', NS(id, "load_cran"), '", "load", {priority: "event"})}')))),
             actionButton(NS(id, "add_pkgs"), shiny::icon("angle-right"),
                          style = 'height: calc(1.5em + 1.5rem + 2px)')),

--- a/tests/testthat/test-sidebar.R
+++ b/tests/testthat/test-sidebar.R
@@ -117,6 +117,7 @@ test_that("Reactivity of sidebar", {
 
   # set select_pkg back to "-"
   app$set_inputs(`sidebar-select_pkg` = "-")
+  app$wait_for_idle()
   # expect version to be set to "-" as well
   expect_equal(app$get_value(input = "sidebar-select_ver"), "-")
   


### PR DESCRIPTION
Ensures users can not create and select packages from CRAN that don't exist