### PR TITLE
Sync meter color on HTML reports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: riskassessment
 Title: A web app designed to interface with the `riskmetric` package
-Version: 3.0.0.9006
+Version: 3.0.0.9007
 Authors@R: c( 
     person("Aaron", "Clark", role = c("aut", "cre"), email = "aaron.clark@biogen.com"),
     person("Robert", "Krajcik", role = "aut", email = "robert.krajcik@biogen.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Added tests for the code and function explorers
 * Added repo specification to configuration file (#701)
 * Fix typo in Privileges table (#719)
+* Fixed bug where HTML reports displayed a darker green in the cards' meters
 
 # riskassessment 3.0.0
 

--- a/inst/report_downloads/reportHtml.Rmd
+++ b/inst/report_downloads/reportHtml.Rmd
@@ -227,6 +227,14 @@ createGrid <- function(metrics){
   padding-right: 6em;
   height: 6em;
 }
+
+meter::-webkit-meter-optimum-value {background: #9CFF94;}
+meter::-webkit-meter-suboptimum-value{background:#FFD070;}
+meter::-webkit-meter-even-less-good-value{background:#FF765B;}
+
+meter::-moz-meter-bar {background: #FF765B;}  /* color of bar*/
+meter::-moz-meter-optimum-value {background: #9CFF94;} 
+meter::-moz-meter-suboptimum-value{background:#FFD070;}  
 ```
 
 ```{r general_pkg_info}


### PR DESCRIPTION
Closes #727.
Fixed by copying css from app over to html report. Results:

![image](https://github.com/pharmaR/riskassessment/assets/17878953/5b942652-97de-4fd3-bf35-4ecfad163fa9)
