### PR TITLE
Point tidyr download to archive

### DIFF
--- a/tests/testthat/test-introJS.R
+++ b/tests/testthat/test-introJS.R
@@ -18,7 +18,7 @@ test_that("The introJS module works as expected for admins", {
   }
   if (!file.exists(app_tar_loc)) {
     download.file(
-      "https://cran.r-project.org/src/contrib/tidyr_1.3.0.tar.gz", #This will need to be changed in the future
+      "https://cran.r-project.org/src/contrib/Archive/tidyr/tidyr_1.3.0.tar.gz",
       app_tar_loc,
       mode = "wb"
     )


### PR DESCRIPTION
The day arrived where the test needs to point to the archive instead of available packages